### PR TITLE
Fix/add prop types

### DIFF
--- a/lib/components/addons/InfoBox.js
+++ b/lib/components/addons/InfoBox.js
@@ -72,7 +72,6 @@ var InfoBox = (function(_React$PureComponent) {
     var _ref
 
     var _temp, _this, _ret
-
     ;(0, _classCallCheck3.default)(this, InfoBox)
 
     for (
@@ -84,22 +83,24 @@ var InfoBox = (function(_React$PureComponent) {
     }
 
     return (
-      (_ret = ((_temp = ((_this = (0, _possibleConstructorReturn3.default)(
-        this,
-        (_ref =
-          InfoBox.__proto__ ||
-          (0, _getPrototypeOf2.default)(InfoBox)).call.apply(
-          _ref,
-          [this].concat(args)
-        )
-      )),
-      _this)),
-      (_this.state = (0, _defineProperty3.default)(
-        {},
-        _constants.INFO_BOX,
-        null
-      )),
-      _temp)),
+      (_ret =
+        ((_temp =
+          ((_this = (0, _possibleConstructorReturn3.default)(
+            this,
+            (_ref =
+              InfoBox.__proto__ ||
+              (0, _getPrototypeOf2.default)(InfoBox)).call.apply(
+              _ref,
+              [this].concat(args)
+            )
+          )),
+          _this)),
+        (_this.state = (0, _defineProperty3.default)(
+          {},
+          _constants.INFO_BOX,
+          null
+        )),
+        _temp)),
       (0, _possibleConstructorReturn3.default)(_this, _ret)
     )
   }
@@ -258,17 +259,85 @@ var updaterMap = {
   },
 }
 
-InfoBox.contextTypes = ((_InfoBox$contextTypes = {}),
-(0, _defineProperty3.default)(
-  _InfoBox$contextTypes,
-  _constants.MAP,
-  _propTypes2.default.object
-),
-(0, _defineProperty3.default)(
-  _InfoBox$contextTypes,
-  _constants.ANCHOR,
-  _propTypes2.default.object
-),
-_InfoBox$contextTypes)
+InfoBox.propTypes = {
+  /**
+   * @type InfoBoxOptions
+   */
+  defaultOptions: _propTypes2.default.any,
+
+  /**
+   * @type LatLng|LatLngLiteral
+   */
+  defaultPosition: _propTypes2.default.any,
+
+  /**
+   * @type boolean
+   */
+  defaultVisible: _propTypes2.default.bool,
+
+  /**
+   * @type number
+   */
+  defaultZIndex: _propTypes2.default.number,
+
+  /**
+   * @type InfoBoxOptions
+   */
+  options: _propTypes2.default.any,
+
+  /**
+   * @type LatLng|LatLngLiteral
+   */
+  position: _propTypes2.default.any,
+
+  /**
+   * @type boolean
+   */
+  visible: _propTypes2.default.bool,
+
+  /**
+   * @type number
+   */
+  zIndex: _propTypes2.default.number,
+
+  /**
+   * function
+   */
+  onCloseClick: _propTypes2.default.func,
+
+  /**
+   * function
+   */
+  onDomReady: _propTypes2.default.func,
+
+  /**
+   * function
+   */
+  onContentChanged: _propTypes2.default.func,
+
+  /**
+   * function
+   */
+  onPositionChanged: _propTypes2.default.func,
+
+  /**
+   * function
+   */
+  onZindexChanged: _propTypes2.default.func,
+}
+
+InfoBox.contextTypes =
+  ((_InfoBox$contextTypes = {}),
+  (0, _defineProperty3.default)(
+    _InfoBox$contextTypes,
+    _constants.MAP,
+    _propTypes2.default.object
+  ),
+  (0, _defineProperty3.default)(
+    _InfoBox$contextTypes,
+    _constants.ANCHOR,
+    _propTypes2.default.object
+  ),
+  _InfoBox$contextTypes)
 
 exports.default = InfoBox

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@breather/react-google-maps",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "React.js Google Maps integration component",
   "license": "MIT",
   "author": {

--- a/src/components/addons/InfoBox.jsx
+++ b/src/components/addons/InfoBox.jsx
@@ -19,6 +19,78 @@ import { MAP, ANCHOR, INFO_BOX } from "../../constants"
  * @see http://htmlpreview.github.io/?https://github.com/googlemaps/v3-utility-library/blob/master/infobox/docs/reference.html
  */
 class InfoBox extends React.PureComponent {
+  static propTypes = {
+    /**
+     * @type InfoBoxOptions
+     */
+    defaultOptions: PropTypes.any,
+
+    /**
+     * @type LatLng|LatLngLiteral
+     */
+    defaultPosition: PropTypes.any,
+
+    /**
+     * @type boolean
+     */
+    defaultVisible: PropTypes.bool,
+
+    /**
+     * @type number
+     */
+    defaultZIndex: PropTypes.number,
+
+    /**
+     * @type InfoBoxOptions
+     */
+    options: PropTypes.any,
+
+    /**
+     * @type LatLng|LatLngLiteral
+     */
+    position: PropTypes.any,
+
+    /**
+     * @type boolean
+     */
+    visible: PropTypes.bool,
+
+    /**
+     * @type number
+     */
+    zIndex: PropTypes.number,
+
+    /**
+     * function
+     */
+    onCloseClick: PropTypes.func,
+
+    /**
+     * function
+     */
+    onDomReady: PropTypes.func,
+
+    /**
+     * function
+     */
+    onContentChanged: PropTypes.func,
+
+    /**
+     * function
+     */
+    onPositionChanged: PropTypes.func,
+
+    /**
+     * function
+     */
+    onZindexChanged: PropTypes.func,
+  }
+
+  static contextTypes = {
+    [MAP]: PropTypes.object,
+    [ANCHOR]: PropTypes.object,
+  }
+
   state = {
     [INFO_BOX]: null,
   }


### PR DESCRIPTION
Nicolas removed PropType on InfoBox but unfortunately it introduced a bug... This package is doing crazy stuff based on props type : https://github.com/breather/react-google-maps/blob/master/src/utils/MapChildHelper.js#L29 and breather.com was working until now because `withAnalytics` was triggering too much refreshes. So here is the fix on the src file and built file.